### PR TITLE
fix(api): fileServer.timeout keep growing

### DIFF
--- a/packages/api/src/utils/fileserv.ts
+++ b/packages/api/src/utils/fileserv.ts
@@ -77,6 +77,7 @@ export class FileServer {
 
     if(hasTimeout) { // && !fileExist
       clearTimeout(hasTimeout.timeout);
+      this.#timeouts = this.#timeouts.filter(({filename: f}) => f !== filename);
     }
     return false;
   }


### PR DESCRIPTION
item aren't removed from fileServer.timeout when file doesn't exists anymore.